### PR TITLE
[API] Fixed self-assignment issue that prevented /channel route from returning any data

### DIFF
--- a/ARCHIVORD.API/src/index.ts
+++ b/ARCHIVORD.API/src/index.ts
@@ -67,10 +67,10 @@ app.get('/guilds/:guildId/channels', (req, res) => {
 	const chanData: archivord.Channels = {};
 	chanRef.get().then((snapshot) => {
 		snapshot.forEach((doc) => {
-			const chanData = doc.data();
+			const chanDatum = doc.data();
 			chanData[doc.id] = {
-				'channelName': chanData.channelName,
-				'topic': chanData.topic,
+				'channelName': chanDatum.channelName,
+				'topic': chanDatum.topic || null,
 			};
 		});
 		res.set('Content-Type', 'application/json');


### PR DESCRIPTION
The /channels function was iterating through each document and assigning the data to itself. Fixes #16. 